### PR TITLE
Add HomeViewModel

### DIFF
--- a/lib/viewmodels/home_view_model.dart
+++ b/lib/viewmodels/home_view_model.dart
@@ -1,0 +1,31 @@
+import 'package:acote_task/models/user_model.dart';
+import 'package:acote_task/repositories/home_repository.dart';
+import 'package:acote_task/services/acote_api_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'home_view_model.g.dart';
+
+@riverpod
+class HomeViewModel extends _$HomeViewModel {
+  @override
+  Future<List<UserModel>> build() {
+    return getUserLists();
+  }
+
+  Future<List<UserModel>> getUserLists() async {
+    final homeRepository = HomeRepository(acoteApiService: AcoteApiService());
+    return await homeRepository.getUserLists();
+  }
+
+  // 기존 userList에 광고 삽입
+  List<dynamic> insertAds(List<UserModel> users) {
+    List<dynamic> itemLists = [];
+    for (int i = 0; i < users.length; i++) {
+      itemLists.add(users[i]);
+      if ((i + 1) % 10 == 0) {
+        itemLists.add('ad');
+      }
+    }
+    return itemLists;
+  }
+}

--- a/lib/viewmodels/home_view_model.g.dart
+++ b/lib/viewmodels/home_view_model.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'home_view_model.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$homeViewModelHash() => r'fadd98ff598cbc1e52332f2b355327bad435db36';
+
+/// See also [HomeViewModel].
+@ProviderFor(HomeViewModel)
+final homeViewModelProvider =
+    AutoDisposeAsyncNotifierProvider<HomeViewModel, List<UserModel>>.internal(
+  HomeViewModel.new,
+  name: r'homeViewModelProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$homeViewModelHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$HomeViewModel = AutoDisposeAsyncNotifier<List<UserModel>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member


### PR DESCRIPTION
- 비지니스로직을 호출하고 받아온 데이터를 HomeView에 제공하기위한 HomeViewModel 추가
- riverpod generator를 이용하여 provider 생성
- 리스트 10개 단위로 광고를 삽입하기 위한 로직 추가